### PR TITLE
Overhaul to have all 3 ad types work with last sdks versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,19 @@ Now I\`ll explain here the basic usage of this "module": </br>
 **Take in mind, this module requires from you basic knowledge of p4a and buidozer. In case you dont understand something, you can check Google firebase docs or `example` folder.**
 
 Modifications to buildozer.spec file:
-- `android.permissions = INTERNET, ACCESS_NETWORK_STATE`
-- `android.api = 30`
-- `android.minapi = 21`
-- `android.sdk = 24`
-- `android.ndk = 19b`
-- `android.gradle_dependencies = 'com.google.firebase:firebase-ads:10.2.0'`
+- `android.permissions = INTERNET, ACCESS_NETWORK_STATE, AD_ID `
+- `android.api = 33`
+- `android.ndk = 25b`
+- `android.gradle_dependencies = com.google.android.gms:play-services-ads:22.1.0,com.google.gms:google-services:4.3.15,androidx.work:work-runtime:2.7.1`
 - `p4a.branch = master`
 - `android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713 (TEST app ID, in release use your own app ID)`
+- `android.add_src = java`
 
 It's better to mention, that you dont actually need to download jnius on your pc. 
 Buildozer can download it when building your app.
 
 To use the module, you have to initialize mobile ads first. You can do it by this function:</br>
-`simpleam.simpleam_init("Your AdMob ID")`</br>
-Dont supply an argument, if you want to use TEST ID. This **APPLIES TO ALL ADMOB OBJECTS**
+`simpleam.simpleam_init()`</br>
 
 Now, you can actually create some objects. Let's create a banner:</br>
 `banner = simpleam.Banner(ad_id=None, position="BOTTOM", size="SMART_BANNER")`
@@ -76,34 +74,31 @@ It takes some code examples, but I couldnt say it's hard to understand. Let's st
 points = 0
 rewarded = simplead.Rewarded(ad_id=None)
 
-class Callback(simpleam.RewardedCallbacks):
-"""Callback class, which takes events from rewarded video, and makes some manipulations. 
-   As an example, it adds 50 points, if user fully watched the ad.
-   It also indicates if ad is loaded, if it failed to load, if it's closed and etc."""
-		
-    def on_rewarded_loaded(self):
-        print("SIMPLEAM: Ad is loaded!")
+class FullScreenContentCallbacks:
+    def onAdClicked (self):
+        print("simpleam: FullScreenContentCallbacks : onAdClicked")
+    def onAdDismissedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdDismissedFullScreenContent")
+    def onAdFailedToShowFullScreenContent(self, adError):
+        print(f"simpleam: FullScreenContentCallbacks : onAdFailedToShowFullScreenContent : {adError.toString()}")
+    def onAdImpression(self):
+        print("simpleam: FullScreenContentCallbacks : onAdImpression")
+    def onAdShowedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdShowedFullScreenContent")
 
-    def on_rewarded_opened(self):
-        print("SIMPLEAM: Ad is opened!")
+class PaidEventCallbacks:
+    def onPaidEvent(self, value):
+        print(f"simpleam: PaidEventCallbacks : onPaidEvent : code : {value.getCurrencyCode()}, precision : {value.getPrecisionType()}, value: {value.getValueMicros()}")      
+        
+class OnUserEarnedRewardCallbacks:
+    def onUserEarnedReward(self, reward):
+        print(f"simpleam: OnUserEarnedRewardCallbacks : onUserEarnedReward : amount : {reward.getAmount()}, type  : {reward.getType()}")   
+		points += 50
 
-    def on_rewarded_started(self):
-        print("SIMPLEAM: Ad is started!")
-
-    def on_rewarded_closed(self):
-        print("SIMPLEAM: Ad closed!")
-
-    def on_rewarded_success(self, reward):
-        points += 50
-        print(f"SIMPLEAM: Ad succesfully ended!")
-
-    def on_rewarded_left(self):
-        print("SIMPLEAM: Ad left application!")
-
-    def on_rewarded_load_fail(self, num):
-        print("SIMPLEAM: Ad failed to load!")
-
-rewarded.set_listener(Callbacks()) # Loads our listener in the rewarded ad class. Now we can load a video
+# Loads our listeners in the rewarded ad class. Now we can load a video
+rewarded.set_FullScreenContentCallbacks(self, FullScreenContentCallbacks()):        
+rewarded.set_OnUserEarnedRewardListener(self, OnUserEarnedRewardCallbacks()):
+rewarded.set_OnPaidEventListener(self, PaidEventCallbacks()):
 rewarded.load_ad()
 
 if rewarded.is_loaded():

--- a/examples/simpleam.py
+++ b/examples/simpleam.py
@@ -1,13 +1,11 @@
-try:
-    from jnius import autoclass, PythonJavaClass, java_method #type: ignore
-    from android.runnable import run_on_ui_thread #type: ignore
-    from time import sleep
-except:
-    print("SIMPLEAM: Failed to load android and java modules.")
-    raise ImportError
+from jnius import autoclass, PythonJavaClass, JavaClass, java_method
+from android.runnable import run_on_ui_thread
 
-class JC:
-    "Java & AdMob classes enumerator"
+TEST_BANNER_ID = "ca-app-pub-3940256099942544/6300978111"
+TEST_INTERSTITIAL_ID = "ca-app-pub-3940256099942544/1033173712"
+TEST_REWARDED_ID = "ca-app-pub-3940256099942544/5224354917"
+
+class JavaBridge:
     View = autoclass("android.view.View")
     Activity = autoclass("org.kivy.android.PythonActivity")
     AdMobAdapter = autoclass("com.google.ads.mediation.admob.AdMobAdapter")
@@ -16,48 +14,79 @@ class JC:
     AdView = autoclass("com.google.android.gms.ads.AdView")
     Bundle = autoclass("android.os.Bundle")
     Gravity = autoclass("android.view.Gravity")
-    InterstitialAd = autoclass("com.google.android.gms.ads.InterstitialAd")
+    RewardedAd = autoclass("com.google.android.gms.ads.rewarded.RewardedAd")
+    InterstitialAd = autoclass("com.google.android.gms.ads.interstitial.InterstitialAd")
     LayoutParams = autoclass("android.view.ViewGroup$LayoutParams")
     LinearLayout = autoclass("android.widget.LinearLayout")
     MobileAds = autoclass("com.google.android.gms.ads.MobileAds")
-
-def simpleam_init(app_id: str = None):
+    # Since version 20.0 of play-services-ads some callbacks mecanisms are abstract class which pyjnius cannot manage
+    # In that case we have to provide our own java class that extends admob api and can take a jnius-managed interface as constructor parameter
+    AdListener = autoclass("com.simpleam.simpleamAdListener") # instead of "com.google.android.gms.ads.AdListener"
+    InterstitialAdLoadCallback = autoclass("com.simpleam.simpleamInterstitialAdLoadCallback") # instead of "com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback"
+    RewardedAdLoadCallback = autoclass("com.simpleam.simpleamRewardedAdLoadCallback") # instead of "com.google.android.gms.ads.rewarded.RewardedAdLoadCallback"
+    FullScreenContentCallback  = autoclass("com.simpleam.simpleamFullScreenContentCallback") # instead of "com.google.android.gms.ads.FullScreenContentCallback"
+    
+def simpleam_init():
     """ Initializes AdMob MobileAds class. Use this function at the start to use all functionality. 
-        \nTakes AdMob app id as an argument. Test app Ids is used if no argument was supplied"""
-    app_id = app_id if app_id else "ca-app-pub-3940256099942544~3347511713"
-    JC.MobileAds.initialize(JC.Activity.mActivity, app_id)
+        \nMake sure your APPLICATION_ID is set in your buildozer.spec like this:
+        \nandroid.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713"""
+    JavaBridge.MobileAds.initialize(JavaBridge.Activity.mActivity)
 
 class AdObject:
     def __init__(self, ad_id):
-        self.AD_ID = ad_id
-        self.admob_obj = None
-        self.loaded = False
+        self.ad_id = ad_id
+        self.context = JavaBridge.Activity.mActivity
+        self.ad = None
+        self._loaded = False
+        self._loading = False
 
     @run_on_ui_thread
     def load_ad(self, filters: dict = {}) -> None:
-        self.loaded = False
-        self.admob_obj.loadAd(self.get_builder(filters).build())
+        pass
     
     @run_on_ui_thread
     def destroy(self) -> None:
-        self.admob_obj.destroy()
+        self.ad.destroy()
 
-    def get_builder(self, ad_filters: dict = {}) -> JC.AdRequestBuilder:
-        " Builds ad depending on you're filters. "
-        builder = JC.AdRequestBuilder()
+    def is_loaded(self) -> bool:
+        return self._loaded
+        
+    def is_loading(self) -> bool:
+        return self._loading
+        
+    def get_builder(self, ad_filters: dict = {}) -> JavaBridge.AdRequestBuilder:
+        "Creates an AdRequest contains targeting information used to fetch an ad"
+        builder = JavaBridge.AdRequestBuilder()
         if ad_filters.get("children", None):
             builder.tagForChildDirectedTreatment(ad_filters["children"]) # Builds a child-friendly ad
         if ad_filters.get("family", None):
-            extras = JC.Bundle()
+            extras = JavaBridge.Bundle()
             extras.putBoolean("is_designed_for_families", ad_filters["family"]) # Builds a family-friendly ad
-            builder.addNetworkExtrasBundle(JC.AdMobAdapter, extras)
+            builder.addNetworkExtrasBundle(JavaBridge.AdMobAdapter, extras)
         return builder
 
-class Banner(AdObject):
+class AdListener:
+    def onAdClicked(self):
+        print("simpleam: AdListener : onAdClicked")
+    def onAdClosed(self):
+        print("simpleam: AdListener : onAdClosed")
+    def onAdFailedToLoad(self, adError):
+        print(f"simpleam: AdListener : onAdFailedToLoad : {adError.toString()}")
+    def onAdImpression(self):
+        print("simpleam: AdListener : onAdImpression")
+    def onAdLoaded(self):
+        print("simpleam: AdListener : onAdLoaded")
+    def onAdOpened(self):
+        print("simpleam: AdListener : onAdOpened")
+    def onAdSwipeGestureClicked(self):
+        print("simpleam: AdListener : onAdSwipeGestureClicked")
+
+class Banner(AdObject, PythonJavaClass):
     " AdMob banner ad class. "
+    __javainterfaces__ = ("com.simpleam.simpleamAdListenerInterface", )
+    __javacontext__ = "app"
     @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/6300978111", 
-    			 position = "BOTTOM", size = "SMART_BANNER"):
+    def __init__(self, ad_id: str = TEST_BANNER_ID, position = "BOTTOM", size = "SMART_BANNER"):
         """ Banner has ability to create custom size. You can pass different arguments as position and size.
     		\nIf you want to use custom size - pass tuple as an argument with 2 integers.
             \n(Take in mind, some sizes might NOT work)
@@ -81,154 +110,207 @@ class Banner(AdObject):
             \n- RIGHT;
             \n- CENTER.
             \n(For more check https://developer.android.com/reference/android/view/Gravity)"""
+            
         super().__init__(ad_id)
-        self.visible = False
-        banner_position = getattr(JC.Gravity, position, JC.Gravity.BOTTOM)
-        banner_size = size if isinstance(size, tuple) else getattr(JC.AdSize, size, JC.AdSize.SMART_BANNER)
-
-        self.admob_obj = JC.AdView(JC.Activity.mActivity)
-        self.admob_obj.setAdUnitId(self.AD_ID)
-        self.admob_obj.setAdSize(banner_size)
-        self.admob_obj.setVisibility(JC.View.GONE)
-        adLayoutParams = JC.LayoutParams(JC.LayoutParams.MATCH_PARENT, JC.LayoutParams.WRAP_CONTENT)
-        self.admob_obj.setLayoutParams(adLayoutParams)
-        layout = JC.LinearLayout(JC.Activity.mActivity)
-        layout.setGravity(banner_position)
-        layout.addView(self.admob_obj)
-        layoutParams = JC.LayoutParams(JC.LayoutParams.MATCH_PARENT, JC.LayoutParams.MATCH_PARENT)
+        self.ad = JavaBridge.AdView(JavaBridge.Activity.mActivity)
+        self.ad.setAdUnitId(self.ad_id)
+        self.ad.setAdSize(size if isinstance(size, tuple) else getattr(JavaBridge.AdSize, size, JavaBridge.AdSize.SMART_BANNER))
+        self.ad.setVisibility(JavaBridge.View.GONE)
+        self.adListener = AdListener()
+        self.ad.setAdListener(JavaBridge.AdListener(self))
+        adLayoutParams = JavaBridge.LayoutParams(JavaBridge.LayoutParams.MATCH_PARENT, JavaBridge.LayoutParams.WRAP_CONTENT)
+        self.ad.setLayoutParams(adLayoutParams)
+        layout = JavaBridge.LinearLayout(JavaBridge.Activity.mActivity)
+        layout.setGravity(getattr(JavaBridge.Gravity, position, JavaBridge.Gravity.BOTTOM))
+        layout.addView(self.ad)
+        layoutParams = JavaBridge.LayoutParams(JavaBridge.LayoutParams.MATCH_PARENT, JavaBridge.LayoutParams.MATCH_PARENT)
         layout.setLayoutParams(layoutParams)
-        JC.Activity.addContentView(layout, layoutParams)
+        self.context.addContentView(layout, layoutParams)
+        self.visibility = False;
 
+    @java_method("()V")
+    def onAdClicked (self):
+        self.adListener.onAdClicked()
+    @java_method("()V")
+    def onAdClosed(self):
+        self._loaded = False
+        self.adListener.onAdClosed()
+    @java_method("(Lcom/google/android/gms/ads/LoadAdError;)V")
+    def onAdFailedToLoad(self, adError):
+        self._loaded = False
+        self._loading = False
+        self.adListener.onAdFailedToLoad(adError)
+    @java_method("()V")
+    def onAdImpression(self):
+        self.adListener.onAdImpression()
+    @java_method("()V")
+    def onAdLoaded(self):
+        self._loaded = True
+        self._loading = False
+        self.adListener.onAdLoaded()
+    @java_method("()V")
+    def onAdOpened(self):
+        self.adListener.onAdOpened()
+    @java_method("()V")
+    def onAdSwipeGestureClicked(self):
+        self.adListener.onAdSwipeGestureClicked()
+      
     @run_on_ui_thread
+    def load_ad(self, filters: dict = {}) -> None:
+        self._loaded = False
+        self.ad.loadAd(self.get_builder(filters).build())
+        self._loading = True
+        
+    @run_on_ui_thread
+    def _get_visibility(self) -> None:
+        self.visibility = self.ad.getVisibility() == JavaBridge.View.VISIBLE
+        
+    def get_visibility(self) -> bool:
+        self._get_visibility()
+        return self.visibility
+        
+    @run_on_ui_thread
+    def _set_visibility(self, visibility: bool = True) -> None:
+        self.ad.setVisibility(JavaBridge.View.VISIBLE if visibility else JavaBridge.View.GONE)
+        
     def set_visibility(self, visibility: bool = True) -> None:
-        self.visible = visibility
-        self.admob_obj.setVisibility(JC.View.VISIBLE if visibility else JC.View.GONE)
+        self._set_visibility(visibility)
+        self.visibility = True
+        
+    def setAdListener(self, adListener : AdListener):
+        self.adListener = AdListener
 
-class Interstitial(AdObject):
+class Interstitial(AdObject, PythonJavaClass):
     " AdMob interstitial ad class. "
-    @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/1033173712"):
+    __javainterfaces__  = ("com.simpleam.simpleamInterstitialAdLoadCallbackInterface", )
+    __javacontext__ = "app"
+    def __init__(self, ad_id: str = TEST_INTERSTITIAL_ID):
         """ Interstitial has 2 variations which depend on AdMob ID.
     	    \nTEST image interstitial: `ca-app-pub-3940256099942544/1033173712`
     	    \nTEST video interstitial: `ca-app-pub-3940256099942544/8691691433`.
     	    \nIf no argument was supplied, interstitial would be ALWAYS image."""
         super().__init__(ad_id)
-        self.admob_obj = JC.InterstitialAd(JC.Activity.mActivity)
-        self.admob_obj.setAdUnitId(self.AD_ID)
 
-    @run_on_ui_thread
-    def _is_loaded(self) -> None:
-        self.loaded = self.admob_obj.isLoaded()
+    @java_method('(Lcom/google/android/gms/ads/LoadAdError;)V')
+    def onAdFailedToLoad(self, loadAdError):
+        self._loading = False
+        self._loaded = False
+        print('simpleam: Failed to load interstitial ad')
+        print(loadAdError.toString())
+
+    @java_method("(Lcom/google/android/gms/ads/interstitial/InterstitialAd;)V")
+    def onAdLoaded(self, ad):
+        self._loading = False
+        self.ad = ad
+        self._loaded = True
         
-    def is_loaded(self) -> bool:
-        self._is_loaded()
-        return self.loaded
-
+    @run_on_ui_thread
+    def load_ad(self, filters: dict = {}) -> None:
+        self._loaded = False
+        JavaBridge.InterstitialAd.load(self.context, self.ad_id, self.get_builder(filters).build(),JavaBridge.InterstitialAdLoadCallback(self))
+        self._loading = True
+        
     @run_on_ui_thread
     def show(self) -> None:
         if self.is_loaded():
-            self.admob_obj.show()
+            self.ad.show(self.context)
 
-class Rewarded(AdObject):
+class FullScreenContentCallbacks:
+    def onAdClicked (self):
+        print("simpleam: FullScreenContentCallbacks : onAdClicked")
+    def onAdDismissedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdDismissedFullScreenContent")
+    def onAdFailedToShowFullScreenContent(self, adError):
+        print(f"simpleam: FullScreenContentCallbacks : onAdFailedToShowFullScreenContent : {adError.toString()}")
+    def onAdImpression(self):
+        print("simpleam: FullScreenContentCallbacks : onAdImpression")
+    def onAdShowedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdShowedFullScreenContent")
+
+class PaidEventCallbacks:
+    def onPaidEvent(self, value):
+        print(f"simpleam: PaidEventCallbacks : onPaidEvent : code : {value.getCurrencyCode()}, precision : {value.getPrecisionType()}, value: {value.getValueMicros()}")      
+        
+class OnUserEarnedRewardCallbacks:
+    def onUserEarnedReward(self, reward):
+        print(f"simpleam: OnUserEarnedRewardCallbacks : onUserEarnedReward : amount : {reward.getAmount()}, type  : {reward.getType()}")      
+
+
+class Rewarded(AdObject, PythonJavaClass):
     " AdMob rewarded ad class. "
-    @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/5224354917"):
-        """Rewarded ads need rewarded video listener.
-           Video listener is used for checking events like `on_rewarded_succes` or `on_rewarded_loaded`
-           \nIt should look like `RewardedCallbacks` class.
-           \nYou have to set up it like this: `rewarded.set_listener(my_callback_listener)
+    __javainterfaces__ = (
+        "com.google.android.gms.ads.OnPaidEventListener",
+        "com.google.android.gms.ads.OnUserEarnedRewardListener",
+        "com.simpleam.simpleamFullScreenContentCallbackInterface",
+        "com.simpleam.simpleamRewardedAdLoadCallbackInterface", 
+    )
+    __javacontext__ = "app"
+    def __init__(self, ad_id: str = TEST_REWARDED_ID):
+        """Rewarded ads need multiple callbacks/listener : FullScreenContentCallbacks, PaidEventCallbacks, OnUserEarnedRewardCallbacks"
+           \nLook at https://developers.google.com/android/reference/com/google/android/gms/ads/rewarded/RewardedAd for more information
+           \nYou can provide your own implementations using set_FullScreenContentCallbacks, set_OnUserEarnedRewardListener, set_OnPaidEventListener
         """
         super().__init__(ad_id)
-        self.viewed_ad = False
-        self.admob_obj = JC.MobileAds.getRewardedVideoAdInstance(JC.Activity.mActivity)
-    
-    @run_on_ui_thread
-    def set_listener(self, callback_listener):
-        self.rewarded_listener = RVListener(callback_listener, self)
-        self.admob_obj.setRewardedVideoAdListener(self.rewarded_listener)
+        self._full_screen_content_callback = FullScreenContentCallbacks()
+        self._user_earned_reward_listener = OnUserEarnedRewardCallbacks()
+        self._paid_event_listener = PaidEventCallbacks()   
 
+    @java_method("(Lcom/google/android/gms/ads/AdValue;)V")
+    def onPaidEvent(self, value):
+        self._paid_event_listener.onPaidEvent(value)
+
+    @java_method("(Lcom/google/android/gms/ads/rewarded/RewardItem;)V")
+    def onUserEarnedReward(self, reward):
+        self._user_earned_reward_listener.onUserEarnedReward(reward)
+
+    @java_method("()V")
+    def onAdClicked (self):
+        self._full_screen_content_callback.onAdClicked()
+    @java_method("()V")
+    def onAdDismissedFullScreenContent(self):
+        self._full_screen_content_callback.onAdDismissedFullScreenContent()
+    @java_method("(Lcom/google/android/gms/ads/AdError;)V")
+    def onAdFailedToShowFullScreenContent(self, adError):
+        self._full_screen_content_callback.onAdFailedToShowFullScreenContent(adError)
+    @java_method("()V")
+    def onAdImpression(self):
+        self._full_screen_content_callback.onAdImpression()
+    @java_method("()V")
+    def onAdShowedFullScreenContent(self):
+        self._full_screen_content_callback.onAdShowedFullScreenContent()
+
+    @java_method('(Lcom/google/android/gms/ads/LoadAdError;)V')
+    def onAdFailedToLoad(self, loadAdError):
+        self.loading = False
+        self.loaded = False
+        print(loadAdError.toString())
+ 
+    @java_method("(Lcom/google/android/gms/ads/rewarded/RewardedAd;)V")
+    def onAdLoaded(self, ad):
+        self._loading = False
+        self.ad = ad
+        self.ad.setFullScreenContentCallback(JavaBridge.FullScreenContentCallback(self))
+        self.ad.setOnPaidEventListener(self)
+        self._loaded = True
+                
+    def set_FullScreenContentCallbacks(self, callbacks: FullScreenContentCallbacks):
+        self._full_screen_content_callback = callbacks
+        
+    def set_OnUserEarnedRewardListener(self, callback: OnUserEarnedRewardCallbacks):
+        self._user_earned_reward_listener = callback
+        
+    def set_OnPaidEventListener(self, callback: PaidEventCallbacks):
+        self._paid_event_listener = callback
+        
     @run_on_ui_thread
     def load_ad(self, filters: dict = {}) -> None:
-        self.loaded = False
-        self.admob_obj.loadAd(self.AD_ID, self.get_builder(filters).build())
-
-    @run_on_ui_thread
-    def _is_loaded(self) -> None:
-        self.loaded = self.admob_obj.isLoaded()
-
-    @run_on_ui_thread
-    def _show(self) -> None:
-        self.admob_obj.show()
+        self._loaded = False
+        JavaBridge.RewardedAd.load(self.context, self.ad_id, self.get_builder(filters).build(),JavaBridge.RewardedAdLoadCallback(self))
+        self._loading = True
         
-    def is_loaded(self) -> bool:
-        self._is_loaded()
-        return self.loaded
-    
+    @run_on_ui_thread
     def show(self) -> None:
-    	if self.is_loaded():
-            while not self.viewed_ad:
-                self._show()
-                sleep(0.15)
+        if self.is_loaded():
+            self.ad.show(self.context, self)
+        
 
-class RVListener(PythonJavaClass):
-    "AdMob revarded video listener class."
-    __javainterfaces__ = ("com.google.android.gms.ads.reward.RewardedVideoAdListener", )
-    __javacontext__ = "app"
-
-    def __init__(self, reward_listener, rewarded_object):
-        self._rewarded = rewarded_object
-        self._listener = reward_listener
-
-    @java_method("()V")
-    def onRewardedVideoAdLoaded(self):
-        self._rewarded.viewed_ad = False
-        self._listener.on_rewarded_loaded()
-
-    @java_method("()V")
-    def onRewardedVideoAdOpened(self):
-        self._listener.on_rewarded_opened()
-
-    @java_method("()V")
-    def onRewardedVideoStarted(self):
-        self._listener.on_rewarded_load_fail
-
-    @java_method("()V")
-    def onRewardedVideoAdClosed(self):
-        self._rewarded.viewed_ad = True
-        self._listener.on_rewarded_closed()
-
-    @java_method("(Lcom/google/android/gms/ads/reward/RewardItem;)V")
-    def onRewarded(self, reward):
-        self._listener.on_rewarded_success(reward)
-
-    @java_method("()V")
-    def onRewardedVideoAdLeftApplication(self):
-        self._rewarded.viewed_ad = True
-        self._listener.on_rewarded_left()
-
-    @java_method("(I)V")
-    def onRewardedVideoAdFailedToLoad(self, num):
-        self._rewarded.viewed_ad = False
-        self._listener.on_rewarded_load_fail(num)
-
-class RewardedCallbacks:
-    def on_rewarded_loaded(self):
-        print("SIMPLEAM: Ad is loaded!")
-
-    def on_rewarded_opened(self):
-        print("SIMPLEAM: Ad is opened!")
-
-    def on_rewarded_started(self):
-        print("SIMPLEAM: Ad is started!")
-
-    def on_rewarded_closed(self):
-        print("SIMPLEAM: Ad closed!")
-
-    def on_rewarded_success(self, reward):
-        print(f"SIMPLEAM: Ad succesfully ended!")
-
-    def on_rewarded_left(self):
-        print("SIMPLEAM: Ad left application!")
-
-    def on_rewarded_load_fail(self, num):
-        print("SIMPLEAM: Ad failed to load!")

--- a/java/simpleamAdListener.java
+++ b/java/simpleamAdListener.java
@@ -1,0 +1,46 @@
+package com.simpleam;
+import com.simpleam.simpleamAdListenerInterface;
+import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.LoadAdError;
+
+public class simpleamAdListener extends AdListener{
+	simpleamAdListenerInterface python_callbacks;
+	public simpleamAdListener(simpleamAdListenerInterface my_interface){
+		python_callbacks = my_interface;
+	}
+    @Override
+    public void onAdClicked(){
+		python_callbacks.onAdClicked ();
+        return;
+	}
+    @Override
+    public void onAdClosed(){
+		python_callbacks.onAdClosed();
+        return;
+	}
+    @Override
+    public void onAdFailedToLoad(LoadAdError adError){
+		python_callbacks.onAdFailedToLoad(adError);
+        return;
+	}
+	@Override
+    public void onAdImpression(){
+		python_callbacks.onAdImpression();
+        return;
+	}
+	@Override
+    public void onAdLoaded(){
+		python_callbacks.onAdLoaded();
+        return;
+	}
+	@Override
+    public void onAdOpened(){
+		python_callbacks.onAdOpened();
+        return;
+	}
+	@Override
+    public void onAdSwipeGestureClicked(){
+		python_callbacks.onAdSwipeGestureClicked();
+        return;
+	}
+}

--- a/java/simpleamAdListenerInterface.java
+++ b/java/simpleamAdListenerInterface.java
@@ -1,0 +1,12 @@
+package com.simpleam;
+import com.google.android.gms.ads.LoadAdError;
+
+public interface simpleamAdListenerInterface {
+    public void onAdClicked();
+    public void onAdClosed();
+    public void onAdFailedToLoad(LoadAdError adError);
+    public void onAdImpression();
+    public void onAdLoaded();
+    public void onAdOpened();
+    public void onAdSwipeGestureClicked();
+}

--- a/java/simpleamFullScreenContentCallback.java
+++ b/java/simpleamFullScreenContentCallback.java
@@ -1,0 +1,36 @@
+package com.simpleam;
+import com.simpleam.simpleamFullScreenContentCallbackInterface;
+import com.google.android.gms.ads.FullScreenContentCallback;
+import com.google.android.gms.ads.AdError;
+
+public class simpleamFullScreenContentCallback extends FullScreenContentCallback{
+	simpleamFullScreenContentCallbackInterface python_callbacks;
+	public simpleamFullScreenContentCallback(simpleamFullScreenContentCallbackInterface my_interface){
+		python_callbacks = my_interface;
+	}
+    @Override
+    public void onAdClicked (){
+		python_callbacks.onAdClicked();
+        return;
+	}
+	@Override
+    public void onAdDismissedFullScreenContent(){
+		python_callbacks.onAdDismissedFullScreenContent();
+        return;
+	}
+	@Override
+    public void onAdFailedToShowFullScreenContent(AdError adError){
+		python_callbacks.onAdFailedToShowFullScreenContent(adError);
+        return;
+	}
+	@Override
+    public void onAdImpression (){
+		python_callbacks.onAdImpression ();
+        return;
+	}
+	@Override
+    public void onAdShowedFullScreenContent (){
+		python_callbacks.onAdShowedFullScreenContent();
+        return;
+	}
+}

--- a/java/simpleamFullScreenContentCallbackInterface.java
+++ b/java/simpleamFullScreenContentCallbackInterface.java
@@ -1,0 +1,10 @@
+package com.simpleam;
+import com.google.android.gms.ads.AdError;
+
+public interface simpleamFullScreenContentCallbackInterface {
+    public void onAdClicked ();
+    public void onAdDismissedFullScreenContent();
+    public void onAdFailedToShowFullScreenContent(AdError adError);
+    public void onAdImpression ();
+    public void onAdShowedFullScreenContent ();
+}

--- a/java/simpleamInterstitialAdLoadCallback.java
+++ b/java/simpleamInterstitialAdLoadCallback.java
@@ -1,0 +1,23 @@
+package com.simpleam;
+import com.simpleam.simpleamInterstitialAdLoadCallbackInterface;
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.interstitial.InterstitialAd;
+
+public class simpleamInterstitialAdLoadCallback extends InterstitialAdLoadCallback{
+	simpleamInterstitialAdLoadCallbackInterface python_callbacks;
+	public simpleamInterstitialAdLoadCallback(simpleamInterstitialAdLoadCallbackInterface my_interface){
+		python_callbacks = my_interface;
+	}
+    @Override
+    public void onAdFailedToLoad(LoadAdError adError){
+		python_callbacks.onAdFailedToLoad(adError);
+        return;
+	}
+	
+	@Override
+    public void onAdLoaded(InterstitialAd adT){
+		python_callbacks.onAdLoaded(adT);
+        return;
+	}
+}

--- a/java/simpleamInterstitialAdLoadCallbackInterface.java
+++ b/java/simpleamInterstitialAdLoadCallbackInterface.java
@@ -1,0 +1,9 @@
+package com.simpleam;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.interstitial.InterstitialAd;
+
+public interface simpleamInterstitialAdLoadCallbackInterface {
+
+    public void onAdFailedToLoad(LoadAdError adError);
+    public void onAdLoaded(InterstitialAd adT);
+}

--- a/java/simpleamRewardedAdLoadCallback.java
+++ b/java/simpleamRewardedAdLoadCallback.java
@@ -1,0 +1,23 @@
+package com.simpleam;
+import com.simpleam.simpleamRewardedAdLoadCallbackInterface;
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.rewarded.RewardedAd;
+
+public class simpleamRewardedAdLoadCallback extends RewardedAdLoadCallback{
+	simpleamRewardedAdLoadCallbackInterface python_callbacks;
+	public simpleamRewardedAdLoadCallback(simpleamRewardedAdLoadCallbackInterface my_interface){
+		python_callbacks = my_interface;
+	}
+    @Override
+    public void onAdFailedToLoad(LoadAdError adError){
+		python_callbacks.onAdFailedToLoad(adError);
+        return;
+	}
+	
+	@Override
+    public void onAdLoaded(RewardedAd adT){
+		python_callbacks.onAdLoaded(adT);
+        return;
+	}
+}

--- a/java/simpleamRewardedAdLoadCallbackInterface.java
+++ b/java/simpleamRewardedAdLoadCallbackInterface.java
@@ -1,0 +1,9 @@
+package com.simpleam;
+import com.google.android.gms.ads.LoadAdError;
+import com.google.android.gms.ads.rewarded.RewardedAd;
+
+public interface simpleamRewardedAdLoadCallbackInterface {
+
+    public void onAdFailedToLoad(LoadAdError adError);
+    public void onAdLoaded(RewardedAd adT);
+}

--- a/simpleam.py
+++ b/simpleam.py
@@ -1,13 +1,11 @@
-try:
-    from jnius import autoclass, PythonJavaClass, java_method #type: ignore
-    from android.runnable import run_on_ui_thread #type: ignore
-    from time import sleep
-except:
-    print("SIMPLEAM: Failed to load android and java modules.")
-    raise ImportError
+from jnius import autoclass, PythonJavaClass, JavaClass, java_method
+from android.runnable import run_on_ui_thread
 
-class JC:
-    "Java & AdMob classes enumerator"
+TEST_BANNER_ID = "ca-app-pub-3940256099942544/6300978111"
+TEST_INTERSTITIAL_ID = "ca-app-pub-3940256099942544/1033173712"
+TEST_REWARDED_ID = "ca-app-pub-3940256099942544/5224354917"
+
+class JavaBridge:
     View = autoclass("android.view.View")
     Activity = autoclass("org.kivy.android.PythonActivity")
     AdMobAdapter = autoclass("com.google.ads.mediation.admob.AdMobAdapter")
@@ -16,48 +14,79 @@ class JC:
     AdView = autoclass("com.google.android.gms.ads.AdView")
     Bundle = autoclass("android.os.Bundle")
     Gravity = autoclass("android.view.Gravity")
-    InterstitialAd = autoclass("com.google.android.gms.ads.InterstitialAd")
+    RewardedAd = autoclass("com.google.android.gms.ads.rewarded.RewardedAd")
+    InterstitialAd = autoclass("com.google.android.gms.ads.interstitial.InterstitialAd")
     LayoutParams = autoclass("android.view.ViewGroup$LayoutParams")
     LinearLayout = autoclass("android.widget.LinearLayout")
     MobileAds = autoclass("com.google.android.gms.ads.MobileAds")
-
-def simpleam_init(app_id: str = None):
+    # Since version 20.0 of play-services-ads some callbacks mecanisms are abstract class which pyjnius cannot manage
+    # In that case we have to provide our own java class that extends admob api and can take a jnius-managed interface as constructor parameter
+    AdListener = autoclass("com.simpleam.simpleamAdListener") # instead of "com.google.android.gms.ads.AdListener"
+    InterstitialAdLoadCallback = autoclass("com.simpleam.simpleamInterstitialAdLoadCallback") # instead of "com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback"
+    RewardedAdLoadCallback = autoclass("com.simpleam.simpleamRewardedAdLoadCallback") # instead of "com.google.android.gms.ads.rewarded.RewardedAdLoadCallback"
+    FullScreenContentCallback  = autoclass("com.simpleam.simpleamFullScreenContentCallback") # instead of "com.google.android.gms.ads.FullScreenContentCallback"
+    
+def simpleam_init():
     """ Initializes AdMob MobileAds class. Use this function at the start to use all functionality. 
-        \nTakes AdMob app id as an argument. Test app Ids is used if no argument was supplied"""
-    app_id = app_id if app_id else "ca-app-pub-3940256099942544~3347511713"
-    JC.MobileAds.initialize(JC.Activity.mActivity, app_id)
+        \nMake sure your APPLICATION_ID is set in your buildozer.spec like this:
+        \nandroid.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713"""
+    JavaBridge.MobileAds.initialize(JavaBridge.Activity.mActivity)
 
 class AdObject:
     def __init__(self, ad_id):
-        self.AD_ID = ad_id
-        self.admob_obj = None
-        self.loaded = False
+        self.ad_id = ad_id
+        self.context = JavaBridge.Activity.mActivity
+        self.ad = None
+        self._loaded = False
+        self._loading = False
 
     @run_on_ui_thread
     def load_ad(self, filters: dict = {}) -> None:
-        self.loaded = False
-        self.admob_obj.loadAd(self.get_builder(filters).build())
+        pass
     
     @run_on_ui_thread
     def destroy(self) -> None:
-        self.admob_obj.destroy()
+        self.ad.destroy()
 
-    def get_builder(self, ad_filters: dict = {}) -> JC.AdRequestBuilder:
-        " Builds ad depending on you're filters. "
-        builder = JC.AdRequestBuilder()
+    def is_loaded(self) -> bool:
+        return self._loaded
+        
+    def is_loading(self) -> bool:
+        return self._loading
+        
+    def get_builder(self, ad_filters: dict = {}) -> JavaBridge.AdRequestBuilder:
+        "Creates an AdRequest contains targeting information used to fetch an ad"
+        builder = JavaBridge.AdRequestBuilder()
         if ad_filters.get("children", None):
             builder.tagForChildDirectedTreatment(ad_filters["children"]) # Builds a child-friendly ad
         if ad_filters.get("family", None):
-            extras = JC.Bundle()
+            extras = JavaBridge.Bundle()
             extras.putBoolean("is_designed_for_families", ad_filters["family"]) # Builds a family-friendly ad
-            builder.addNetworkExtrasBundle(JC.AdMobAdapter, extras)
+            builder.addNetworkExtrasBundle(JavaBridge.AdMobAdapter, extras)
         return builder
 
-class Banner(AdObject):
+class AdListener:
+    def onAdClicked(self):
+        print("simpleam: AdListener : onAdClicked")
+    def onAdClosed(self):
+        print("simpleam: AdListener : onAdClosed")
+    def onAdFailedToLoad(self, adError):
+        print(f"simpleam: AdListener : onAdFailedToLoad : {adError.toString()}")
+    def onAdImpression(self):
+        print("simpleam: AdListener : onAdImpression")
+    def onAdLoaded(self):
+        print("simpleam: AdListener : onAdLoaded")
+    def onAdOpened(self):
+        print("simpleam: AdListener : onAdOpened")
+    def onAdSwipeGestureClicked(self):
+        print("simpleam: AdListener : onAdSwipeGestureClicked")
+
+class Banner(AdObject, PythonJavaClass):
     " AdMob banner ad class. "
+    __javainterfaces__ = ("com.simpleam.simpleamAdListenerInterface", )
+    __javacontext__ = "app"
     @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/6300978111", 
-    			 position = "BOTTOM", size = "SMART_BANNER"):
+    def __init__(self, ad_id: str = TEST_BANNER_ID, position = "BOTTOM", size = "SMART_BANNER"):
         """ Banner has ability to create custom size. You can pass different arguments as position and size.
     		\nIf you want to use custom size - pass tuple as an argument with 2 integers.
             \n(Take in mind, some sizes might NOT work)
@@ -81,154 +110,207 @@ class Banner(AdObject):
             \n- RIGHT;
             \n- CENTER.
             \n(For more check https://developer.android.com/reference/android/view/Gravity)"""
+            
         super().__init__(ad_id)
-        self.visible = False
-        banner_position = getattr(JC.Gravity, position, JC.Gravity.BOTTOM)
-        banner_size = size if isinstance(size, tuple) else getattr(JC.AdSize, size, JC.AdSize.SMART_BANNER)
-
-        self.admob_obj = JC.AdView(JC.Activity.mActivity)
-        self.admob_obj.setAdUnitId(self.AD_ID)
-        self.admob_obj.setAdSize(banner_size)
-        self.admob_obj.setVisibility(JC.View.GONE)
-        adLayoutParams = JC.LayoutParams(JC.LayoutParams.MATCH_PARENT, JC.LayoutParams.WRAP_CONTENT)
-        self.admob_obj.setLayoutParams(adLayoutParams)
-        layout = JC.LinearLayout(JC.Activity.mActivity)
-        layout.setGravity(banner_position)
-        layout.addView(self.admob_obj)
-        layoutParams = JC.LayoutParams(JC.LayoutParams.MATCH_PARENT, JC.LayoutParams.MATCH_PARENT)
+        self.ad = JavaBridge.AdView(JavaBridge.Activity.mActivity)
+        self.ad.setAdUnitId(self.ad_id)
+        self.ad.setAdSize(size if isinstance(size, tuple) else getattr(JavaBridge.AdSize, size, JavaBridge.AdSize.SMART_BANNER))
+        self.ad.setVisibility(JavaBridge.View.GONE)
+        self.adListener = AdListener()
+        self.ad.setAdListener(JavaBridge.AdListener(self))
+        adLayoutParams = JavaBridge.LayoutParams(JavaBridge.LayoutParams.MATCH_PARENT, JavaBridge.LayoutParams.WRAP_CONTENT)
+        self.ad.setLayoutParams(adLayoutParams)
+        layout = JavaBridge.LinearLayout(JavaBridge.Activity.mActivity)
+        layout.setGravity(getattr(JavaBridge.Gravity, position, JavaBridge.Gravity.BOTTOM))
+        layout.addView(self.ad)
+        layoutParams = JavaBridge.LayoutParams(JavaBridge.LayoutParams.MATCH_PARENT, JavaBridge.LayoutParams.MATCH_PARENT)
         layout.setLayoutParams(layoutParams)
-        JC.Activity.addContentView(layout, layoutParams)
+        self.context.addContentView(layout, layoutParams)
+        self.visibility = False;
 
+    @java_method("()V")
+    def onAdClicked (self):
+        self.adListener.onAdClicked()
+    @java_method("()V")
+    def onAdClosed(self):
+        self._loaded = False
+        self.adListener.onAdClosed()
+    @java_method("(Lcom/google/android/gms/ads/LoadAdError;)V")
+    def onAdFailedToLoad(self, adError):
+        self._loaded = False
+        self._loading = False
+        self.adListener.onAdFailedToLoad(adError)
+    @java_method("()V")
+    def onAdImpression(self):
+        self.adListener.onAdImpression()
+    @java_method("()V")
+    def onAdLoaded(self):
+        self._loaded = True
+        self._loading = False
+        self.adListener.onAdLoaded()
+    @java_method("()V")
+    def onAdOpened(self):
+        self.adListener.onAdOpened()
+    @java_method("()V")
+    def onAdSwipeGestureClicked(self):
+        self.adListener.onAdSwipeGestureClicked()
+      
     @run_on_ui_thread
+    def load_ad(self, filters: dict = {}) -> None:
+        self._loaded = False
+        self.ad.loadAd(self.get_builder(filters).build())
+        self._loading = True
+        
+    @run_on_ui_thread
+    def _get_visibility(self) -> None:
+        self.visibility = self.ad.getVisibility() == JavaBridge.View.VISIBLE
+        
+    def get_visibility(self) -> bool:
+        self._get_visibility()
+        return self.visibility
+        
+    @run_on_ui_thread
+    def _set_visibility(self, visibility: bool = True) -> None:
+        self.ad.setVisibility(JavaBridge.View.VISIBLE if visibility else JavaBridge.View.GONE)
+        
     def set_visibility(self, visibility: bool = True) -> None:
-        self.visible = visibility
-        self.admob_obj.setVisibility(JC.View.VISIBLE if visibility else JC.View.GONE)
+        self._set_visibility(visibility)
+        self.visibility = True
+        
+    def setAdListener(self, adListener : AdListener):
+        self.adListener = AdListener
 
-class Interstitial(AdObject):
+class Interstitial(AdObject, PythonJavaClass):
     " AdMob interstitial ad class. "
-    @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/1033173712"):
+    __javainterfaces__  = ("com.simpleam.simpleamInterstitialAdLoadCallbackInterface", )
+    __javacontext__ = "app"
+    def __init__(self, ad_id: str = TEST_INTERSTITIAL_ID):
         """ Interstitial has 2 variations which depend on AdMob ID.
     	    \nTEST image interstitial: `ca-app-pub-3940256099942544/1033173712`
     	    \nTEST video interstitial: `ca-app-pub-3940256099942544/8691691433`.
     	    \nIf no argument was supplied, interstitial would be ALWAYS image."""
         super().__init__(ad_id)
-        self.admob_obj = JC.InterstitialAd(JC.Activity.mActivity)
-        self.admob_obj.setAdUnitId(self.AD_ID)
 
-    @run_on_ui_thread
-    def _is_loaded(self) -> None:
-        self.loaded = self.admob_obj.isLoaded()
+    @java_method('(Lcom/google/android/gms/ads/LoadAdError;)V')
+    def onAdFailedToLoad(self, loadAdError):
+        self._loading = False
+        self._loaded = False
+        print('simpleam: Failed to load interstitial ad')
+        print(loadAdError.toString())
+
+    @java_method("(Lcom/google/android/gms/ads/interstitial/InterstitialAd;)V")
+    def onAdLoaded(self, ad):
+        self._loading = False
+        self.ad = ad
+        self._loaded = True
         
-    def is_loaded(self) -> bool:
-        self._is_loaded()
-        return self.loaded
-
+    @run_on_ui_thread
+    def load_ad(self, filters: dict = {}) -> None:
+        self._loaded = False
+        JavaBridge.InterstitialAd.load(self.context, self.ad_id, self.get_builder(filters).build(),JavaBridge.InterstitialAdLoadCallback(self))
+        self._loading = True
+        
     @run_on_ui_thread
     def show(self) -> None:
         if self.is_loaded():
-            self.admob_obj.show()
+            self.ad.show(self.context)
 
-class Rewarded(AdObject):
+class FullScreenContentCallbacks:
+    def onAdClicked (self):
+        print("simpleam: FullScreenContentCallbacks : onAdClicked")
+    def onAdDismissedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdDismissedFullScreenContent")
+    def onAdFailedToShowFullScreenContent(self, adError):
+        print(f"simpleam: FullScreenContentCallbacks : onAdFailedToShowFullScreenContent : {adError.toString()}")
+    def onAdImpression(self):
+        print("simpleam: FullScreenContentCallbacks : onAdImpression")
+    def onAdShowedFullScreenContent(self):
+        print("simpleam: FullScreenContentCallbacks : onAdShowedFullScreenContent")
+
+class PaidEventCallbacks:
+    def onPaidEvent(self, value):
+        print(f"simpleam: PaidEventCallbacks : onPaidEvent : code : {value.getCurrencyCode()}, precision : {value.getPrecisionType()}, value: {value.getValueMicros()}")      
+        
+class OnUserEarnedRewardCallbacks:
+    def onUserEarnedReward(self, reward):
+        print(f"simpleam: OnUserEarnedRewardCallbacks : onUserEarnedReward : amount : {reward.getAmount()}, type  : {reward.getType()}")      
+
+
+class Rewarded(AdObject, PythonJavaClass):
     " AdMob rewarded ad class. "
-    @run_on_ui_thread
-    def __init__(self, ad_id: str = "ca-app-pub-3940256099942544/5224354917"):
-        """Rewarded ads need rewarded video listener.
-           Video listener is used for checking events like `on_rewarded_succes` or `on_rewarded_loaded`
-           \nIt should look like `RewardedCallbacks` class.
-           \nYou have to set up it like this: `rewarded.set_listener(my_callback_listener)
+    __javainterfaces__ = (
+        "com.google.android.gms.ads.OnPaidEventListener",
+        "com.google.android.gms.ads.OnUserEarnedRewardListener",
+        "com.simpleam.simpleamFullScreenContentCallbackInterface",
+        "com.simpleam.simpleamRewardedAdLoadCallbackInterface", 
+    )
+    __javacontext__ = "app"
+    def __init__(self, ad_id: str = TEST_REWARDED_ID):
+        """Rewarded ads need multiple callbacks/listener : FullScreenContentCallbacks, PaidEventCallbacks, OnUserEarnedRewardCallbacks"
+           \nLook at https://developers.google.com/android/reference/com/google/android/gms/ads/rewarded/RewardedAd for more information
+           \nYou can provide your own implementations using set_FullScreenContentCallbacks, set_OnUserEarnedRewardListener, set_OnPaidEventListener
         """
         super().__init__(ad_id)
-        self.viewed_ad = False
-        self.admob_obj = JC.MobileAds.getRewardedVideoAdInstance(JC.Activity.mActivity)
-    
-    @run_on_ui_thread
-    def set_listener(self, callback_listener):
-        self.rewarded_listener = RVListener(callback_listener, self)
-        self.admob_obj.setRewardedVideoAdListener(self.rewarded_listener)
+        self._full_screen_content_callback = FullScreenContentCallbacks()
+        self._user_earned_reward_listener = OnUserEarnedRewardCallbacks()
+        self._paid_event_listener = PaidEventCallbacks()   
 
+    @java_method("(Lcom/google/android/gms/ads/AdValue;)V")
+    def onPaidEvent(self, value):
+        self._paid_event_listener.onPaidEvent(value)
+
+    @java_method("(Lcom/google/android/gms/ads/rewarded/RewardItem;)V")
+    def onUserEarnedReward(self, reward):
+        self._user_earned_reward_listener.onUserEarnedReward(reward)
+
+    @java_method("()V")
+    def onAdClicked (self):
+        self._full_screen_content_callback.onAdClicked()
+    @java_method("()V")
+    def onAdDismissedFullScreenContent(self):
+        self._full_screen_content_callback.onAdDismissedFullScreenContent()
+    @java_method("(Lcom/google/android/gms/ads/AdError;)V")
+    def onAdFailedToShowFullScreenContent(self, adError):
+        self._full_screen_content_callback.onAdFailedToShowFullScreenContent(adError)
+    @java_method("()V")
+    def onAdImpression(self):
+        self._full_screen_content_callback.onAdImpression()
+    @java_method("()V")
+    def onAdShowedFullScreenContent(self):
+        self._full_screen_content_callback.onAdShowedFullScreenContent()
+
+    @java_method('(Lcom/google/android/gms/ads/LoadAdError;)V')
+    def onAdFailedToLoad(self, loadAdError):
+        self.loading = False
+        self.loaded = False
+        print(loadAdError.toString())
+ 
+    @java_method("(Lcom/google/android/gms/ads/rewarded/RewardedAd;)V")
+    def onAdLoaded(self, ad):
+        self._loading = False
+        self.ad = ad
+        self.ad.setFullScreenContentCallback(JavaBridge.FullScreenContentCallback(self))
+        self.ad.setOnPaidEventListener(self)
+        self._loaded = True
+                
+    def set_FullScreenContentCallbacks(self, callbacks: FullScreenContentCallbacks):
+        self._full_screen_content_callback = callbacks
+        
+    def set_OnUserEarnedRewardListener(self, callback: OnUserEarnedRewardCallbacks):
+        self._user_earned_reward_listener = callback
+        
+    def set_OnPaidEventListener(self, callback: PaidEventCallbacks):
+        self._paid_event_listener = callback
+        
     @run_on_ui_thread
     def load_ad(self, filters: dict = {}) -> None:
-        self.loaded = False
-        self.admob_obj.loadAd(self.AD_ID, self.get_builder(filters).build())
-
-    @run_on_ui_thread
-    def _is_loaded(self) -> None:
-        self.loaded = self.admob_obj.isLoaded()
-
-    @run_on_ui_thread
-    def _show(self) -> None:
-        self.admob_obj.show()
+        self._loaded = False
+        JavaBridge.RewardedAd.load(self.context, self.ad_id, self.get_builder(filters).build(),JavaBridge.RewardedAdLoadCallback(self))
+        self._loading = True
         
-    def is_loaded(self) -> bool:
-        self._is_loaded()
-        return self.loaded
-    
+    @run_on_ui_thread
     def show(self) -> None:
-    	if self.is_loaded():
-            while not self.viewed_ad:
-                self._show()
-                sleep(0.15)
+        if self.is_loaded():
+            self.ad.show(self.context, self)
+        
 
-class RVListener(PythonJavaClass):
-    "AdMob revarded video listener class."
-    __javainterfaces__ = ("com.google.android.gms.ads.reward.RewardedVideoAdListener", )
-    __javacontext__ = "app"
-
-    def __init__(self, reward_listener, rewarded_object):
-        self._rewarded = rewarded_object
-        self._listener = reward_listener
-
-    @java_method("()V")
-    def onRewardedVideoAdLoaded(self):
-        self._rewarded.viewed_ad = False
-        self._listener.on_rewarded_loaded()
-
-    @java_method("()V")
-    def onRewardedVideoAdOpened(self):
-        self._listener.on_rewarded_opened()
-
-    @java_method("()V")
-    def onRewardedVideoStarted(self):
-        self._listener.on_rewarded_load_fail
-
-    @java_method("()V")
-    def onRewardedVideoAdClosed(self):
-        self._rewarded.viewed_ad = True
-        self._listener.on_rewarded_closed()
-
-    @java_method("(Lcom/google/android/gms/ads/reward/RewardItem;)V")
-    def onRewarded(self, reward):
-        self._listener.on_rewarded_success(reward)
-
-    @java_method("()V")
-    def onRewardedVideoAdLeftApplication(self):
-        self._rewarded.viewed_ad = True
-        self._listener.on_rewarded_left()
-
-    @java_method("(I)V")
-    def onRewardedVideoAdFailedToLoad(self, num):
-        self._rewarded.viewed_ad = False
-        self._listener.on_rewarded_load_fail(num)
-
-class RewardedCallbacks:
-    def on_rewarded_loaded(self):
-        print("SIMPLEAM: Ad is loaded!")
-
-    def on_rewarded_opened(self):
-        print("SIMPLEAM: Ad is opened!")
-
-    def on_rewarded_started(self):
-        print("SIMPLEAM: Ad is started!")
-
-    def on_rewarded_closed(self):
-        print("SIMPLEAM: Ad closed!")
-
-    def on_rewarded_success(self, reward):
-        print(f"SIMPLEAM: Ad succesfully ended!")
-
-    def on_rewarded_left(self):
-        print("SIMPLEAM: Ad left application!")
-
-    def on_rewarded_load_fail(self, num):
-        print("SIMPLEAM: Ad failed to load!")


### PR DESCRIPTION
The examples probably need to be updated.
Needs some testing.
As you can see I had to make some java classes that are then compiled by buildozer.
This is because jnius can't handle abstract java classes. Unless I'm missing something ?
If someone has a solution to avoid self-made java classes, it'd be greatly appreciated.